### PR TITLE
fix: switch to failPlugin instead of failBuild, onSuccess instead of onEnd

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,13 +16,11 @@ switch( true ) {
 }
 
 module.exports = {
-  async onEnd({
-                utils: {
-                  build: { failPlugin, failBuild },
-                },
-              }) {
-
-    // Since calling utils.build.failBuild will not actually fail the build in onPreBuild, moved the conditions in onPreBuild.
+  onPostBuild({
+    utils: {
+      build: { failBuild },
+    },
+  }) {
     if( authMethod === 'na' ) {
       return failBuild(
           'Could not determine auth method.  Please review the plugin README file and verify your environment variables'
@@ -36,7 +34,12 @@ module.exports = {
     else {
       console.log('Cloudflare ' + authMethod + ' Authentication method detected.');
     }
-
+  },
+  async onSuccess({
+                utils: {
+                  build: { failPlugin },
+                },
+              }) {
     console.log('Preparing to trigger Cloudflare cache purge');
     let baseUrl = `https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache`;
     let headers;
@@ -72,7 +75,7 @@ module.exports = {
       }
       console.log('Cloudflare cache purged successfully!');
     } catch (error) {
-      return failBuild('Cloudflare cache purge failed', { error });
+      return failPlugin('Cloudflare cache purge failed', { error });
     }
   },
 };


### PR DESCRIPTION
Hi @chrism2671, thank you for creating this plugin.

We're making a change to how `onSuccess` works.

**Current:**  `onSuccess` occurs after the build command is complete, but before any files are uploaded.
**Upcoming:** `onSuccess`  occurs after the site is deployed, live, and published to production (if applicable).

As a result `onSuccess` and `onEnd` can no longer be used to fail the build.

This PR consists of 3 changes:
1. Moving input validation into `onPostBuild` so the plugin can use `failBuild`.
2. Changing `onEnd` to `onSuccess` since (I'm assuming) we want to clear Cloudflare cache only on successful builds.
3. Using `failPlugin` instead of `failBuild` in `onSuccess` (previously `onEnd`).

Please let me know what you think of the changes.