### PR TITLE
Update README now that onSuccess fires post-deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 Automatically purge Cloudflare cache on Netlify deploy.
 
 ## NOTES:
-* Strictly this plugin triggers the cache purge before deploy (but after build), as this is the only functionality Netlify provides.
 * Cloudflare supports two methods of authentication.  API TOKEN (Recommended) and API KEY (Legacy).
 * In the event the plugin finds both API Token and API Key environment variables, it will default to using API Token as this is the recommended method of authentication.
 


### PR DESCRIPTION
Since https://www.netlify.com/blog/2021/01/28/post-deploy-events-now-available-to-build-plugins/ and https://github.com/chrism2671/netlify-purge-cloudflare-on-deploy/pull/9 the plugin now uses the `onSuccess` event that runs after a successful site deploy.

I think that means we can remove this line from the README?

> * Strictly this plugin triggers the cache purge before deploy (but after build), as this is the only functionality Netlify provides.